### PR TITLE
Update github output syntax

### DIFF
--- a/.github/workflows/test-get-deployment.yml
+++ b/.github/workflows/test-get-deployment.yml
@@ -18,7 +18,7 @@ jobs:
         id: context
         shell: sh
         run: |
-          echo "::set-output name=environment::run-${{ github.run_id }}-${{ github.run_number }}"
+          echo "environment=run-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v6
         id: deployment


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/